### PR TITLE
Make postcode NOT NULL in the address table

### DIFF
--- a/sql/V1_013__address-not-null-postal_code.sql
+++ b/sql/V1_013__address-not-null-postal_code.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.address ALTER COLUMN postal_code SET NOT NULL;


### PR DESCRIPTION
Adds a new flyway migration for making the postcode column `NOT NULL`