### PR TITLE
Split middlenames out of actor table 

### DIFF
--- a/migration-specific-tests/V1_013.sh
+++ b/migration-specific-tests/V1_013.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+function v1_013_before() {
+  docker pull postgres:12-alpine > /dev/null 2>&1
+  docker run --net=host --rm -e PGPASSWORD=$pagilaPassword postgres:12-alpine psql -h $pagilaHost -p $pagilaPort -U $pagilaUser -d pagila --tuples-only -c "SELECT actor_id, concat_ws(' ', first_name, last_name) FROM actor" > actors_before.txt
+}
+
+function v1_013_after() {
+  docker pull postgres:12-alpine > /dev/null 2>&1
+  docker run --net=host --rm -e PGPASSWORD=$pagilaPassword postgres:12-alpine psql -h $pagilaHost -p $pagilaPort -U $pagilaUser -d pagila --tuples-only -c "SELECT actor_id, concat_ws(' ', rtrim(concat_ws(' ', first_name, middle_name), ' '), last_name) FROM actor" > actors_after.txt
+}
+
+function v1_013_test() {
+  if ! diff -q actors_before.txt actors_after.txt > /dev/null ; then
+    echo
+    echo 'Migration v1_013 produced unexpected results. Diff:'
+    diff actors_before.txt actors_after.txt
+    echo
+    return 1
+  fi
+  return 0
+}

--- a/migration-specific-tests/after.sh
+++ b/migration-specific-tests/after.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+AFTER_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+set -e
+
+latest_migrated_version=$(docker run --net=host --rm -e PGPASSWORD=$pagilaPassword postgres:12-alpine psql -h $pagilaHost -p $pagilaPort -U $pagilaUser -d pagila --tuples-only -c "SELECT version FROM flyway_schema_history WHERE script LIKE 'V%' ORDER BY installed_rank DESC LIMIT 1" | xargs)
+
+case $latest_migrated_version in
+  1.013)
+    echo
+    echo 'Running 1.012->1.013 migration test AFTER action'
+    echo
+    source $AFTER_SCRIPT_DIR/V1_013.sh
+    v1_013_after
+    v1_013_test
+    ;;
+esac

--- a/migration-specific-tests/before.sh
+++ b/migration-specific-tests/before.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+BEFORE_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+set -e
+
+latest_migrated_version=$(docker run --net=host --rm -e PGPASSWORD=$pagilaPassword postgres:12-alpine psql -h $pagilaHost -p $pagilaPort -U $pagilaUser -d pagila --tuples-only -c "SELECT version FROM flyway_schema_history WHERE script LIKE 'V%' ORDER BY installed_rank DESC LIMIT 1" | xargs)
+
+case $latest_migrated_version in
+  1.012)
+    echo
+    echo 'Running 1.012->1.013 migration test BEFORE action'
+    echo
+    source $BEFORE_SCRIPT_DIR/V1_013.sh
+    v1_013_before
+    ;;
+esac

--- a/migration-test-prod.sh
+++ b/migration-test-prod.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 echo "Downloading and installing spawnctl..."
 curl -sL https://run.spawn.cc/install | sh > /dev/null 2>&1
 export PATH=$HOME/.spawnctl/bin:$PATH
@@ -28,7 +30,11 @@ docker pull flyway/flyway > /dev/null 2>&1
 echo
 echo "Starting migration of database with flyway"
 
+source $SCRIPT_DIR/migration-specific-tests/before.sh
+
 docker run --net=host --rm -v $PWD/sql:/flyway/sql flyway/flyway migrate -url="jdbc:postgresql://$pagilaHost:$pagilaPort/pagila" -user=$pagilaUser -password=$pagilaPassword
+
+source $SCRIPT_DIR/migration-specific-tests/after.sh
 
 echo "Successfully migrated 'Pagila' database"
 echo

--- a/migration-test-prod.sh
+++ b/migration-test-prod.sh
@@ -13,11 +13,11 @@ echo
 echo "Creating Pagila backup Spawn data container from image '$SPAWN_PAGILA_IMAGE_NAME'..."
 pagilaContainerName=$(spawnctl create data-container --image $SPAWN_PAGILA_IMAGE_NAME --lifetime 10m --accessToken $SPAWNCTL_ACCESS_TOKEN -q)
 
-pagilaJson=$(spawnctl get data-container $pagilaContainerName -o json)
-pagilaHost=$(echo $pagilaJson | jq -r '.host')
-pagilaPort=$(echo $pagilaJson | jq -r '.port')
-pagilaUser=$(echo $pagilaJson | jq -r '.user')
-pagilaPassword=$(echo $pagilaJson | jq -r '.password')
+export pagilaJson=$(spawnctl get data-container $pagilaContainerName -o json)
+export pagilaHost=$(echo $pagilaJson | jq -r '.host')
+export pagilaPort=$(echo $pagilaJson | jq -r '.port')
+export pagilaUser=$(echo $pagilaJson | jq -r '.user')
+export pagilaPassword=$(echo $pagilaJson | jq -r '.password')
 
 echo "Successfully created Spawn data container '$pagilaContainerName'"
 echo

--- a/sql/V1_013__split-actor-middlenames-to-column.sql
+++ b/sql/V1_013__split-actor-middlenames-to-column.sql
@@ -1,0 +1,13 @@
+ALTER TABLE public.actor ADD COLUMN middle_name text NULL;
+
+UPDATE public.actor a1 
+SET middle_name = (
+  SELECT split_part(a1.first_name, ' ', 2) 
+  FROM public.actor a2 
+  WHERE a1.actor_id = a2.actor_id
+),
+first_name = (
+  SELECT split_part(a1.first_name, ' ', 1) 
+  FROM public.actor a2 
+  WHERE a1.actor_id = a2.actor_id
+);


### PR DESCRIPTION
The actor table contains a `first_name` column which actually contains first names and middle names.

This PR adds a new migration to split the first name column into two: `first_name` and `middle_name`. Where actors have middle names, their middle name will be moved to the `middle_name` column and `first_name` will have the middle name removed.

Actors without middle names should be unaffected.

This PR also adds a test for this migration to ensure that we capture the intended behaviour of the migration script. We dump the state of the actors table before the migration, then dump the state of the actors table _after_ the migration and run a `diff` against the two (after rejoining the names appropriately) to ensure that the migration completed as intended.